### PR TITLE
fix: Add a working `cuda` feature

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -1,0 +1,33 @@
+# Runs the test suite on a self-hosted GPU machine with CUDA enabled
+name: GPU tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [dev]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  cuda:
+    name: CUDA tests
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    runs-on: [self-hosted, gpu-ci]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: lurk-lab/ci-workflows
+      - uses: ./.github/actions/gpu-setup
+        with:
+          gpu-framework: 'cuda'
+      - uses: ./.github/actions/ci-env
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: build CUDA benches & examples
+        run: cargo build --benches --examples --release --features cuda

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ portable = [ "blst/portable", "semolina/portable" ]
 # Enable ADX even if the host CPU doesn't support it.
 # Binary can be executed on Broadwell+ and Ryzen+ systems.
 force-adx = [ "blst/force-adx", "semolina/force-adx" ]
+# Enable CUDA, compile with nvcc, and link to GPU kernels
+cuda = []
 cuda-mobile = []
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() {
         return;
     }
 
+    #[cfg(feature = "cuda")]
     if cuda_available() {
         let mut implement_sort: bool = true;
         compile_cuda("cuda/bn254.cu", "bn256_msm_cuda", implement_sort);
@@ -30,8 +31,11 @@ fn main() {
         compile_cuda("cuda/vesta.cu", "vesta_msm_cuda", implement_sort);
         println!("cargo:rerun-if-changed=cuda");
         println!("cargo:rerun-if-env-changed=CXXFLAGS");
-        #[cfg(feature = "cuda")]
         println!("cargo:rustc-cfg=feature=\"cuda\"");
+    } else {
+        println!("warning=feature \"cuda\" was enabled but no valid installation of CUDA was found");
+        println!("warning=the crate's default CPU methods will be compiled instead; NO GPU IMPLEMENTATION WILL USED WHEN CALLING THIS CRATE'S METHODS");
+        println!("warning=please recompile without feature \"cuda\" or provide a valid CUDA configuration");
     }
     println!("cargo:rerun-if-env-changed=NVCC");
 }

--- a/build.rs
+++ b/build.rs
@@ -33,9 +33,9 @@ fn main() {
         println!("cargo:rerun-if-env-changed=CXXFLAGS");
         println!("cargo:rustc-cfg=feature=\"cuda\"");
     } else {
-        println!("warning=feature \"cuda\" was enabled but no valid installation of CUDA was found");
-        println!("warning=the crate's default CPU methods will be compiled instead; NO GPU IMPLEMENTATION WILL USED WHEN CALLING THIS CRATE'S METHODS");
-        println!("warning=please recompile without feature \"cuda\" or provide a valid CUDA configuration");
+        println!("cargo:warning=feature \"cuda\" was enabled but no valid installation of CUDA was found");
+        println!("cargo:warning=the crate's default CPU methods will be compiled instead; NO GPU IMPLEMENTATION WILL BE USED WHEN CALLING THIS CRATE'S METHODS");
+        println!("cargo:warning=please recompile without feature \"cuda\" or provide a valid CUDA installation");
     }
     println!("cargo:rerun-if-env-changed=NVCC");
 }
@@ -103,6 +103,7 @@ fn determine_cc_def(target_arch: &str, default_def: &str) -> Option<String> {
     None
 }
 
+#[cfg(feature = "cuda")]
 fn cuda_available() -> bool {
     match env::var("NVCC") {
         Ok(var) => which::which(var).is_ok(),
@@ -110,6 +111,7 @@ fn cuda_available() -> bool {
     }
 }
 
+#[cfg(feature = "cuda")]
 fn compile_cuda(file_name: &str, output_name: &str, implement_sort: bool) {
     let mut nvcc = cc::Build::new();
     nvcc.cuda(true);

--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,7 @@ fn main() {
         compile_cuda("cuda/vesta.cu", "vesta_msm_cuda", implement_sort);
         println!("cargo:rerun-if-changed=cuda");
         println!("cargo:rerun-if-env-changed=CXXFLAGS");
+        #[cfg(feature = "cuda")]
         println!("cargo:rustc-cfg=feature=\"cuda\"");
     }
     println!("cargo:rerun-if-env-changed=NVCC");


### PR DESCRIPTION
Resolves https://github.com/lurk-lab/arecibo/issues/259 downstream. This PR adds an actual `cuda` feature that can be toggled `grumpkin-msm`, and thus all of its dependents. We also add GPU CI checks.