### PR TITLE
chore: Upgrade `halo2curves` dependency to version `0.6.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cuda-mobile = []
 blst = "~0.3.11"
 semolina = "~0.1.3"
 sppark = "~0.1.2"
-halo2curves = { version = "0.5.0" }
+halo2curves = { version = "0.6.0" }
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev", version = ">=0.3.1, <=0.5", features = ["repr-c"] }
 rand = "^0"
 rand_chacha = "^0"


### PR DESCRIPTION
- Updated `halo2curves` library to latest version (`0.6.0`) for improved functionality and stability

Companion PR of 
- https://github.com/lurk-lab/arecibo/pull/250
- https://github.com/lurk-lab/lurk-rs/pull/1037