### PR TITLE
ci: Introduce 'dev-ci' profile in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,12 @@ harness = false
 [[bench]]
 name = "pasta_msm"
 harness = false
+
+
+[profile.dev-ci]
+inherits = "dev"
+# By compiling dependencies with optimizations, performing tests gets much faster.
+opt-level = 3
+lto = "thin"
+incremental = false
+codegen-units = 16


### PR DESCRIPTION
- A new profile "dev-ci" has been created in the `Cargo.toml` file,