### PR TITLE
chore: Update `pasta_curves` dependency in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ blst = "~0.3.11"
 semolina = "~0.1.3"
 sppark = "~0.1.2"
 halo2curves = { version = "0.6.0" }
-pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev", version = ">=0.3.1, <=0.5", features = ["repr-c"] }
+pasta_curves = { version = "0.5.0", features = ["repr-c"] }
 rand = "^0"
 rand_chacha = "^0"
 rayon = "1.5"


### PR DESCRIPTION
- Upgraded the `pasta_curves` library to version `0.5.0` in the `Cargo.toml` file
- See https://github.com/lurk-lab/arecibo/issues/332